### PR TITLE
[Feature] Add starting fret setting

### DIFF
--- a/src/apps/fretboard/components/Answers.tsx
+++ b/src/apps/fretboard/components/Answers.tsx
@@ -83,9 +83,9 @@ const HintButton = props => {
   )
 }
 
-const Answer = styled(({ children, className }) => {
+const Answer = styled(({ children, className, ...props }) => {
   return (
-    <Flex className={className} p={3} m={1}>
+    <Flex className={className} p={3} m={1} {...props}>
       <Display size="8">{children}</Display>
     </Flex>
   )

--- a/src/apps/fretboard/components/Settings.tsx
+++ b/src/apps/fretboard/components/Settings.tsx
@@ -1,15 +1,18 @@
 import React from "react"
-import { Box } from "rebass"
+import { Box, Flex } from "rebass"
 import styled from "styled-components"
 
 import { SettingsIcon } from "src/components/ui/SettingsIcon"
 import { useStore, useActions } from "src/utils/hooks"
 import { Spacer } from "src/components/ui/Spacer"
 import { Toggle } from "src/components/ui/Toggle"
+import { Display } from "src/components/ui/Typography"
+import { font, fontSize } from "src/Theme"
 
 export const Settings = () => {
   const {
     setAccidentalMode,
+    setStartingFret,
     toggleAccidentals,
     toggleMultipleChoice,
     toggleNotes,
@@ -22,6 +25,7 @@ export const Settings = () => {
     showAccidentals,
     showNotes,
     showSettings,
+    startingFret,
   } = useStore(state => state.fretboard.settings)
 
   return (
@@ -39,11 +43,18 @@ export const Settings = () => {
               Natural notes only
             </Toggle>
             <Toggle selected={multipleChoice} onClick={toggleMultipleChoice}>
-              Multiple choice?
+              Multiple choice
             </Toggle>
           </Box>
 
-          <Spacer my={2} />
+          <Box>
+            <StartAtFret
+              value={startingFret}
+              onChange={event => setStartingFret(event.currentTarget.value)}
+            />
+          </Box>
+
+          <Spacer my={0} />
 
           <Box ml={1}>
             <Toggle
@@ -68,4 +79,42 @@ export const Settings = () => {
 const SettingsContainer = styled(Box)`
   position: absolute;
   top: 70px;
+`
+
+const StartAtFret = styled(({ className, onChange, value }) => {
+  return (
+    <Flex ml={1} my={0.5} className={className}>
+      <Display size="2">Start at fret</Display>
+      <input
+        type="number"
+        step="1"
+        min="1"
+        max="9"
+        value={value}
+        onChange={onChange}
+        onKeyDown={event => event.preventDefault()}
+      />
+    </Flex>
+  )
+})`
+  user-select: none;
+  input {
+    border: 0;
+    background: none;
+    font-family: ${font("display")};
+    ${fontSize("2")};
+    color: #ccc;
+    margin-left: 5px;
+    outline: none;
+    width: 30px;
+    user-select: none;
+    color: transparent;
+    text-shadow: 0 0 0 white;
+    position: relative;
+    top: -1px;
+
+    &:focus {
+      outline: none;
+    }
+  }
 `

--- a/src/apps/fretboard/index.tsx
+++ b/src/apps/fretboard/index.tsx
@@ -7,12 +7,14 @@ import { Posterboard } from "src/components/Posterboard"
 import { Settings } from "src/apps/fretboard/components/Settings"
 import { Answers } from "src/apps/fretboard/components/Answers"
 import { store } from "src/store"
+import { Spacer } from "src/components/ui/Spacer"
 
 export const FretboardApp = () => {
   return (
     <>
       <Posterboard />
       <Scoreboard />
+      <Spacer mt={3} />
       <Fretboard />
       <Answers />
       <Settings />

--- a/src/apps/fretboard/state/fretboard.ts
+++ b/src/apps/fretboard/state/fretboard.ts
@@ -1,7 +1,8 @@
-import { Action, thunk, Thunk } from "easy-peasy"
+import { Action, thunk, Thunk, listen, Listen } from "easy-peasy"
 import { isEqual, shuffle, times, uniqBy } from "lodash"
 import { Note, getNote } from "src/utils/fretboardUtils"
 import { StoreModel } from "src/store"
+import { fretboard } from "."
 
 export interface Fretboard {
   correctAnswers: number
@@ -10,6 +11,9 @@ export interface Fretboard {
   incorrectAnswers: number
   questions: Note[]
   questionCount: number
+
+  // Listeners
+  listeners: Listen<Fretboard>
 
   // Actions
   correctAnswer: Action<Fretboard, void>
@@ -35,6 +39,16 @@ export const fretboardState: Fretboard = {
   flashMessage: "",
   questions: [],
   questionCount: 4,
+
+  listeners: listen(on => {
+    // Whenever a new starting fret has been selected reset the board
+    on(
+      fretboard.settings.setStartingFret,
+      thunk(actions => {
+        actions.pickRandomNote()
+      })
+    )
+  }),
 
   correctAnswer: state => {
     state.correctAnswers++
@@ -84,6 +98,7 @@ export const fretboardState: Fretboard = {
           return getNote({
             mode: state.fretboard.settings.accidentalMode,
             showAccidentals: state.fretboard.settings.showAccidentals,
+            startingFret: state.fretboard.settings.startingFret,
           })
         }),
         "note"

--- a/src/apps/fretboard/state/settings.ts
+++ b/src/apps/fretboard/state/settings.ts
@@ -10,15 +10,17 @@ export interface Settings {
   showHint: boolean
   showNotes: boolean
   showSettings: boolean
+  startingFret: number
 
   // Actions
+  setAccidentalMode: Action<Settings, AccidentalMode>
+  setStartingFret: Action<Settings, number>
+
   toggleAccidentals: Action<Settings, void>
   toggleHint: Action<Settings, void>
   toggleMultipleChoice: Action<Settings, void>
   toggleNotes: Action<Settings, void>
   toggleSettings: Action<Settings, void>
-
-  setAccidentalMode: Action<Settings, AccidentalMode>
 }
 
 export const settingsState: Settings = {
@@ -28,9 +30,14 @@ export const settingsState: Settings = {
   showHint: false,
   showNotes: false,
   showSettings: true,
+  startingFret: 0,
 
   setAccidentalMode: (state, payload) => {
     state.accidentalMode = payload
+  },
+
+  setStartingFret: (state, payload) => {
+    state.startingFret = payload
   },
 
   toggleAccidentals: state => {

--- a/src/utils/fretboardUtils.ts
+++ b/src/utils/fretboardUtils.ts
@@ -46,15 +46,16 @@ export function getNote(props: {
   mode: AccidentalMode
   showAccidentals: boolean
   position?: NotePosition
+  startingFret?: number
 }): Note {
-  const { mode, position, showAccidentals } = props
+  const { mode, position, showAccidentals, startingFret = 1 } = props
 
   let string
   let note
 
   if (!position) {
-    string = random(1, 6)
-    note = random(1, 12)
+    string = random(startingFret, 6)
+    note = random(startingFret, 12)
   } else {
     string = position[0]
     note = position[1]


### PR DESCRIPTION
Allows the user to set the starting fret, for constraining random note choices to further down the fretboard. 

![starting-fret](https://user-images.githubusercontent.com/236943/54663293-fdce7e00-4a9d-11e9-8940-ce6c22881a9c.gif)
