### PR TITLE
[Feature] Add ability to focus on specific strings; add <CycleButton>

### DIFF
--- a/src/apps/fretboard/components/Settings.tsx
+++ b/src/apps/fretboard/components/Settings.tsx
@@ -1,19 +1,17 @@
 import React from "react"
-import { Box, Flex } from "rebass"
+import { Box } from "rebass"
 import styled from "styled-components"
 
 import { SettingsIcon } from "src/components/ui/SettingsIcon"
 import { useStore, useActions } from "src/utils/hooks"
 import { Spacer } from "src/components/ui/Spacer"
-import { Toggle } from "src/components/ui/Toggle"
-import { Display } from "src/components/ui/Typography"
-import { font, fontSize } from "src/Theme"
+import { CycleButton } from "src/components/ui/CycleButton"
 
 export const Settings = () => {
   const {
     setAccidentalMode,
     setStartingFret,
-    toggleAccidentals,
+    setStringFocus,
     toggleMultipleChoice,
     toggleNotes,
     toggleSettings,
@@ -22,10 +20,10 @@ export const Settings = () => {
   const {
     accidentalMode,
     multipleChoice,
-    showAccidentals,
     showNotes,
     showSettings,
     startingFret,
+    stringFocus,
   } = useStore(state => state.fretboard.settings)
 
   return (
@@ -33,43 +31,79 @@ export const Settings = () => {
       <Box onClick={() => toggleSettings()}>
         <SettingsIcon selected={showSettings} />
       </Box>
-      {showSettings && (
-        <Box>
-          <Box mt={1} ml={1}>
-            <Toggle selected={showNotes} onClick={toggleNotes}>
-              Show notes
-            </Toggle>
-            <Toggle selected={!showAccidentals} onClick={toggleAccidentals}>
-              Natural notes only
-            </Toggle>
-            <Toggle selected={multipleChoice} onClick={toggleMultipleChoice}>
-              Multiple choice
-            </Toggle>
-          </Box>
 
+      {showSettings && (
+        <Box mt={2}>
           <Box>
-            <StartAtFret
-              value={startingFret}
-              onChange={event => setStartingFret(event.currentTarget.value)}
+            <CycleButton
+              index={multipleChoice ? 0 : 1}
+              items={["Multiple choice", "Input mode"]}
+              onClick={toggleMultipleChoice}
             />
           </Box>
 
-          <Spacer my={0} />
-
-          <Box ml={1}>
-            <Toggle
-              selected={accidentalMode === "flats"}
-              onClick={() => setAccidentalMode("flats")}
-            >
-              Flats
-            </Toggle>
-            <Toggle
-              selected={accidentalMode === "sharps"}
-              onClick={() => setAccidentalMode("sharps")}
-            >
-              Sharps
-            </Toggle>
+          <Box mt={1}>
+            <CycleButton
+              index={showNotes ? 1 : 0}
+              items={["Show notes", "Hide notes"]}
+              onClick={toggleNotes}
+            />
+            <CycleButton
+              index={() => {
+                switch (accidentalMode) {
+                  case "naturals":
+                    return 0
+                  case "flats":
+                    return 1
+                  case "sharps":
+                    return 2
+                }
+              }}
+              items={[
+                {
+                  label: "Natural notes only",
+                  onSelect: () => setAccidentalMode("naturals"),
+                },
+                {
+                  label: "Flats",
+                  onSelect: () => setAccidentalMode("flats"),
+                },
+                {
+                  label: "Sharps",
+                  onSelect: () => setAccidentalMode("sharps"),
+                },
+              ]}
+            />
           </Box>
+
+          <Box mt={1}>
+            <CycleButton
+              index={stringFocus}
+              onClick={({ index }) => setStringFocus(index)}
+              items={[
+                "All strings",
+                "string 1",
+                "string 2",
+                "string 3",
+                "string 4",
+                "string 5",
+                "string 6",
+              ]}
+            >
+              Focus on
+            </CycleButton>
+            <CycleButton
+              index={startingFret}
+              items={[...Array(13)].map((_, fret) => String(fret))}
+              onClick={() => {
+                setStartingFret(startingFret + 1)
+              }}
+            >
+              Start at fret
+            </CycleButton>
+          </Box>
+
+          <Spacer my={0} />
         </Box>
       )}
     </SettingsContainer>
@@ -79,42 +113,4 @@ export const Settings = () => {
 const SettingsContainer = styled(Box)`
   position: absolute;
   top: 70px;
-`
-
-const StartAtFret = styled(({ className, onChange, value }) => {
-  return (
-    <Flex ml={1} my={0.5} className={className}>
-      <Display size="2">Start at fret</Display>
-      <input
-        type="number"
-        step="1"
-        min="1"
-        max="9"
-        value={value}
-        onChange={onChange}
-        onKeyDown={event => event.preventDefault()}
-      />
-    </Flex>
-  )
-})`
-  user-select: none;
-  input {
-    border: 0;
-    background: none;
-    font-family: ${font("display")};
-    ${fontSize("2")};
-    color: #ccc;
-    margin-left: 5px;
-    outline: none;
-    width: 30px;
-    user-select: none;
-    color: transparent;
-    text-shadow: 0 0 0 white;
-    position: relative;
-    top: -1px;
-
-    &:focus {
-      outline: none;
-    }
-  }
 `

--- a/src/apps/fretboard/state/fretboard.ts
+++ b/src/apps/fretboard/state/fretboard.ts
@@ -48,6 +48,13 @@ export const fretboardState: Fretboard = {
         actions.pickRandomNote()
       })
     )
+
+    on(
+      fretboard.settings.setStringFocus,
+      thunk(actions => {
+        actions.pickRandomNote()
+      })
+    )
   }),
 
   correctAnswer: state => {
@@ -92,17 +99,24 @@ export const fretboardState: Fretboard = {
   pickRandomNote: thunk((actions, _, { getState }) => {
     const state = getState() as StoreModel
 
-    const getNotes = () =>
-      uniqBy(
+    const getNotes = () => {
+      const {
+        accidentalMode,
+        startingFret,
+        stringFocus,
+      } = state.fretboard.settings
+
+      return uniqBy(
         times(4, () => {
           return getNote({
-            mode: state.fretboard.settings.accidentalMode,
-            showAccidentals: state.fretboard.settings.showAccidentals,
-            startingFret: state.fretboard.settings.startingFret,
+            accidentalMode,
+            startingFret,
+            stringFocus,
           })
         }),
         "note"
       )
+    }
 
     let notes = getNotes()
     while (notes.length < 4) {

--- a/src/apps/fretboard/state/settings.ts
+++ b/src/apps/fretboard/state/settings.ts
@@ -1,22 +1,24 @@
 import { Action } from "easy-peasy"
+import { StringRange } from "src/utils/fretboardUtils"
 
-export type AccidentalMode = "flats" | "sharps"
+export type AccidentalMode = "naturals" | "flats" | "sharps"
+export type StringFocus = 0 | StringRange
 
 export interface Settings {
   accidentalMode: AccidentalMode
   multipleChoice: boolean
 
-  showAccidentals: boolean
   showHint: boolean
   showNotes: boolean
   showSettings: boolean
   startingFret: number
+  stringFocus: StringFocus
 
   // Actions
   setAccidentalMode: Action<Settings, AccidentalMode>
   setStartingFret: Action<Settings, number>
+  setStringFocus: Action<Settings, StringFocus>
 
-  toggleAccidentals: Action<Settings, void>
   toggleHint: Action<Settings, void>
   toggleMultipleChoice: Action<Settings, void>
   toggleNotes: Action<Settings, void>
@@ -26,22 +28,27 @@ export interface Settings {
 export const settingsState: Settings = {
   accidentalMode: "flats",
   multipleChoice: true,
-  showAccidentals: true,
   showHint: false,
   showNotes: false,
   showSettings: true,
   startingFret: 1,
+  stringFocus: 0, // 0 is disabled
 
   setAccidentalMode: (state, payload) => {
     state.accidentalMode = payload
   },
 
-  setStartingFret: (state, payload) => {
-    state.startingFret = payload
+  setStartingFret: (state, startingFret) => {
+    // Octive
+    if (startingFret === 13) {
+      // Open string
+      startingFret = 0
+    }
+    state.startingFret = startingFret
   },
 
-  toggleAccidentals: state => {
-    state.showAccidentals = !state.showAccidentals
+  setStringFocus: (state, stringFocus) => {
+    state.stringFocus = stringFocus
   },
 
   toggleHint: state => {

--- a/src/components/Fretboard/Fretboard.tsx
+++ b/src/components/Fretboard/Fretboard.tsx
@@ -10,7 +10,7 @@ import { notes, containsSharpOrFlat } from "src/utils/fretboardUtils"
 import { color } from "src/Theme"
 
 export const Fretboard = _props => {
-  const { showAccidentals, showHint, showNotes } = useStore(state => state.fretboard.settings) // prettier-ignore
+  const { showHint, showNotes } = useStore(state => state.fretboard.settings) // prettier-ignore
   const {
     settings: { accidentalMode },
     currentNote,
@@ -38,9 +38,7 @@ export const Fretboard = _props => {
                 const getVisibility = () => {
                   switch (true) {
                     case showNotes: {
-                      if (showAccidentals) {
-                        return true
-                      } else {
+                      if (accidentalMode === "naturals") {
                         if (containsSharpOrFlat(note)) {
                           return false
                         }
@@ -54,7 +52,8 @@ export const Fretboard = _props => {
                   }
                 }
 
-                const showNote = getVisibility()
+                // Natural notes are falsy
+                const showNote = Boolean(note) && getVisibility()
 
                 return (
                   <NoteContainer

--- a/src/components/ui/CycleButton.tsx
+++ b/src/components/ui/CycleButton.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from "react"
+import styled from "styled-components"
+import { Display } from "src/components/ui/Typography"
+import { Box } from "rebass"
+import { isFunction, isString } from "lodash"
+
+type CycleItem = string | { label: string; onSelect: () => void }
+
+interface CycleButtonProps {
+  children?: React.ReactNode
+  items: CycleItem[]
+  index?: (() => number) | number
+  onClick?: ({ item: any, index: number }) => void
+}
+
+export const CycleButton: React.FC<CycleButtonProps> = ({
+  children,
+  items,
+  index = 0,
+  onClick,
+}) => {
+  const startingIndex = isFunction(index) ? index() : index
+  const [currIndex, setIndex] = useState(startingIndex)
+
+  const getItem = () => {
+    const item = items[currIndex]
+    if (isString(item)) {
+      return {
+        label: item,
+        onSelect: () => null,
+      }
+    } else {
+      return item
+    }
+  }
+
+  const item = getItem()
+
+  if (item.onSelect) {
+    item.onSelect()
+  }
+
+  return (
+    <Button
+      my={0.5}
+      ml={1}
+      selected={false}
+      onClick={() => {
+        let newIndex
+        if (currIndex < items.length - 1) {
+          newIndex = currIndex + 1
+        } else {
+          newIndex = 0
+        }
+
+        setIndex(newIndex)
+
+        if (onClick) {
+          onClick({ item, index: newIndex })
+        }
+      }}
+    >
+      <Display size="2">
+        {children} {item.label}
+      </Display>
+    </Button>
+  )
+}
+
+const Button = styled(Box)`
+  cursor: pointer;
+  user-select: none;
+`

--- a/src/utils/fretboardUtils.ts
+++ b/src/utils/fretboardUtils.ts
@@ -1,5 +1,5 @@
-import { random } from "lodash"
-import { AccidentalMode } from "src/apps/fretboard/state/settings"
+import { isEmpty, random } from "lodash"
+import { AccidentalMode, StringFocus } from "src/apps/fretboard/state/settings"
 
 export const notes = {
   flats: [
@@ -18,9 +18,17 @@ export const notes = {
     ["A", "A♯", "B", "C", "C♯", "D", "D♯", "E", "F", "F♯", "G", "G♯", "A"],
     ["E", "F", "F♯", "G", "G♯", "A", "A♯", "B", "C", "C♯", "D", "D♯", "E"],
   ],
+  naturals: [
+    ["E", "F", "", "G", "", "A", "", "B", "C", "", "D", "", "E"],
+    ["B", "C", "", "D", "", "E", "F", "", "G", "", "A", "", "B"],
+    ["G", "", "A", "", "B", "C", "", "D", "", "E", "F", "", "G"],
+    ["D", "", "E", "F", "", "G", "", "A", "", "B", "C", "", "D"],
+    ["A", "", "B", "C", "", "D", "", "E", "F", "", "G", "", "A"],
+    ["E", "F", "", "G", "", "A", "", "B", "C", "", "D", "", "E"],
+  ],
 }
 
-type StringRange = 1 | 2 | 3 | 4 | 5 | 6
+export type StringRange = 1 | 2 | 3 | 4 | 5 | 6
 type NoteRange = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13
 
 // The position of the note by string and fret
@@ -43,18 +51,18 @@ export interface Note {
  * })
  */
 export function getNote(props: {
-  mode: AccidentalMode
-  showAccidentals: boolean
+  accidentalMode: AccidentalMode
   position?: NotePosition
   startingFret?: number
+  stringFocus?: StringFocus
 }): Note {
-  const { mode, position, showAccidentals, startingFret = 1 } = props
+  const { accidentalMode, position, startingFret = 1, stringFocus = 0 } = props
 
   let string
   let note
 
   if (!position) {
-    string = random(1, 6)
+    string = stringFocus || random(1, 6)
     note = random(startingFret, 12)
   } else {
     string = position[0]
@@ -65,10 +73,14 @@ export function getNote(props: {
   // because 0 (as in [6, 0]) refers to an open string -- in this case the low `E`.
   string--
 
-  const noteName = notes[mode][string][note]
+  const noteName = notes[accidentalMode][string][note]
 
   // Re-run function if we return an invalid result
-  if (!showAccidentals && containsSharpOrFlat(noteName)) {
+  const showAccidentals = accidentalMode !== "naturals"
+  if (
+    (!showAccidentals && containsSharpOrFlat(noteName)) ||
+    isEmpty(noteName)
+  ) {
     return getNote(props)
   }
 


### PR DESCRIPTION
Fixes https://github.com/damassi/fretboard-trainer/issues/19
Fixes https://github.com/damassi/fretboard-trainer/issues/20\

Refactors the settings panel to support a new `<CycleButton>` which simplifies some of the interactions by cycling through entries rather than stacking. 

Additionally adds the ability to focus on individual strings, vs the full range. 

![cycle](https://user-images.githubusercontent.com/236943/54736989-0ccf3200-4b6b-11e9-8749-a8aea09fa9d9.gif)
