### PR TITLE
Separate scoreboard from FretboardApp

### DIFF
--- a/src/apps/fretboard/state/fretboard.ts
+++ b/src/apps/fretboard/state/fretboard.ts
@@ -6,10 +6,8 @@ import { fretboard } from "."
 import { Howl } from "howler"
 
 export interface Fretboard {
-  correctAnswers: number
   currentNote: Note
   flashMessage: string
-  incorrectAnswers: number
   questions: Note[]
   questionCount: number
 
@@ -17,17 +15,11 @@ export interface Fretboard {
   listeners: Listen<Fretboard>
 
   // Actions
-  correctAnswer: Action<Fretboard, void>
-  incorrectAnswer: Action<Fretboard, void>
-
   setQuestions: Action<Fretboard, Note[]>
-  pickAnswer: Thunk<Fretboard, string>
+  pickAnswer: Thunk<Fretboard, string, any, StoreModel>
 
   pickRandomNote: Thunk<Fretboard, void>
   setNote: Action<Fretboard, Note>
-
-  showFlash: Thunk<Fretboard, string>
-  setFlashMessage: Action<Fretboard, string>
 }
 
 export const fretboardState: Fretboard = {
@@ -35,8 +27,6 @@ export const fretboardState: Fretboard = {
     note: "c",
     position: [5, 3],
   },
-  correctAnswers: 0,
-  incorrectAnswers: 0,
   flashMessage: "",
   questions: [],
   questionCount: 4,
@@ -58,23 +48,7 @@ export const fretboardState: Fretboard = {
     )
   }),
 
-  correctAnswer: state => {
-    state.correctAnswers++
-  },
-  incorrectAnswer: state => {
-    state.incorrectAnswers++
-  },
-
-  showFlash: thunk((actions, flashMessage, { dispatch }: any) => {
-    actions.setFlashMessage(flashMessage)
-    dispatch.fretboard.settings.toggleHint()
-    setTimeout(() => {
-      actions.setFlashMessage("")
-      dispatch.fretboard.settings.toggleHint()
-    }, 2000)
-  }),
-
-  pickAnswer: thunk((actions, selectedNote, { getState }) => {
+  pickAnswer: thunk((actions, selectedNote, { getState, dispatch }) => {
     const {
       fretboard: {
         currentNote,
@@ -88,8 +62,8 @@ export const fretboardState: Fretboard = {
     )
 
     if (isCorrect) {
-      actions.showFlash("correct!")
-      setTimeout(() => actions.correctAnswer(), 10)
+      dispatch.scoreboard.showFlash("correct!")
+      setTimeout(() => dispatch.scoreboard.correctAnswer(), 10)
 
       // Play sound
       if (!isMuted) {
@@ -102,8 +76,8 @@ export const fretboardState: Fretboard = {
         sound.play()
       }
     } else {
-      actions.showFlash("incorrect!")
-      setTimeout(() => actions.incorrectAnswer(), 10)
+      dispatch.scoreboard.showFlash("incorrect!")
+      setTimeout(() => dispatch.scoreboard.incorrectAnswer(), 10)
     }
 
     setTimeout(() => {
@@ -141,10 +115,6 @@ export const fretboardState: Fretboard = {
     actions.setNote(notes[0])
     actions.setQuestions(shuffle(notes))
   }),
-
-  setFlashMessage: (state, message) => {
-    state.flashMessage = message
-  },
 
   setNote: (state, currentNote) => {
     state.currentNote = currentNote

--- a/src/components/Scoreboard/Scoreboard.tsx
+++ b/src/components/Scoreboard/Scoreboard.tsx
@@ -6,7 +6,7 @@ import { useStore } from "src/utils/hooks"
 
 export const Scoreboard = () => {
   const { correctAnswers, incorrectAnswers, flashMessage } = useStore(
-    state => state.fretboard
+    state => state.scoreboard
   )
 
   return (

--- a/src/components/Scoreboard/scoreboardState.tsx
+++ b/src/components/Scoreboard/scoreboardState.tsx
@@ -1,0 +1,44 @@
+import { Action, thunk, Thunk } from "easy-peasy"
+import { StoreModel } from "src/store"
+
+export interface ScoreboardModel {
+  correctAnswers: number
+  flashMessage: string
+  incorrectAnswers: number
+
+  // Actions
+  correctAnswer: Action<ScoreboardModel, void>
+  incorrectAnswer: Action<ScoreboardModel, void>
+
+  showFlash: Thunk<ScoreboardModel, string, any, StoreModel>
+  setFlashMessage: Action<ScoreboardModel, string>
+}
+
+export const scoreboard: ScoreboardModel = {
+  correctAnswers: 0,
+  incorrectAnswers: 0,
+  flashMessage: "",
+
+  correctAnswer: state => {
+    state.correctAnswers++
+  },
+
+  incorrectAnswer: state => {
+    state.incorrectAnswers++
+  },
+
+  setFlashMessage: (state, message) => {
+    state.flashMessage = message
+  },
+
+  showFlash: thunk((actions, flashMessage, { dispatch }: any) => {
+    actions.setFlashMessage(flashMessage)
+
+    // TODO: Move hint toggling to a listener inside of fretboardState
+    dispatch.fretboard.settings.toggleHint()
+    setTimeout(() => {
+      actions.setFlashMessage("")
+      dispatch.fretboard.settings.toggleHint()
+    }, 2000)
+  }),
+}

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -1,8 +1,12 @@
 import { createStore, EasyPeasyConfig } from "easy-peasy"
-import { fretboard, FretboardModel } from "src/apps/fretboard/state"
-
 import { createLogger } from "redux-logger"
 import { save, load } from "redux-localstorage-simple"
+
+import {
+  scoreboard,
+  ScoreboardModel,
+} from "./components/Scoreboard/scoreboardState"
+import { fretboard, FretboardModel } from "src/apps/fretboard/state"
 
 const STORAGE_SETTINGS = {
   namespace: "fretboard-trainer",
@@ -11,11 +15,13 @@ const STORAGE_SETTINGS = {
 
 export interface StoreModel {
   fretboard: FretboardModel
+  scoreboard: ScoreboardModel
 }
 
 export const store = createStore<StoreModel, EasyPeasyConfig>(
   {
     fretboard,
+    scoreboard,
   },
   {
     middleware: [


### PR DESCRIPTION
Decouples the scoreboard from the Fretboard app. This is in prep for https://github.com/damassi/fretboard-trainer/pull/27