### PR TITLE
[Refactor] Move global settings from fretboard to SettingsModel

### DIFF
--- a/src/apps/fretboard/components/Answers.tsx
+++ b/src/apps/fretboard/components/Answers.tsx
@@ -11,12 +11,10 @@ import { Spacer } from "src/components/ui/Spacer"
 
 export const Answers = _props => {
   const { pickAnswer } = useActions(actions => actions.fretboard)
-  const answerInputRef = useRef(null)
+  const { questions } = useStore(state => state.fretboard)
+  const { multipleChoice } = useStore(state => state.settings)
 
-  const {
-    questions,
-    settings: { multipleChoice },
-  } = useStore(state => state.fretboard)
+  const answerInputRef = useRef(null)
 
   return (
     <Flex flexDirection="column" alignItems="center">
@@ -67,8 +65,8 @@ export const Answers = _props => {
 }
 
 const HintButton = props => {
-  const { showHint } = useStore(state => state.fretboard.settings)
-  const { toggleHint } = useActions(actions => actions.fretboard.settings)
+  const { showHint } = useStore(state => state.settings)
+  const { toggleHint } = useActions(actions => actions.settings)
 
   return (
     <Box pt={2}>

--- a/src/apps/fretboard/components/VolumeToggle.tsx
+++ b/src/apps/fretboard/components/VolumeToggle.tsx
@@ -4,9 +4,8 @@ import { color } from "src/Theme"
 import { Box } from "rebass"
 
 export const VolumeToggle: React.FC = () => {
-  const { isMuted } = useStore(state => state.fretboard.settings)
-  const { toggleMuted } = useActions(actions => actions.fretboard.settings)
-
+  const { isMuted } = useStore(state => state.settings)
+  const { toggleMuted } = useActions(actions => actions.settings)
   const iconColor = isMuted ? color("black60") : color("white")
 
   return (

--- a/src/apps/fretboard/index.tsx
+++ b/src/apps/fretboard/index.tsx
@@ -12,7 +12,7 @@ import { store } from "src/store"
 export const FretboardApp: React.FC<RouteComponentProps> = () => {
   return (
     <>
-      <Link to="/">
+      <Link to="/intervals">
         <Posterboard>Fretboard Trainer</Posterboard>
       </Link>
 

--- a/src/apps/fretboard/index.tsx
+++ b/src/apps/fretboard/index.tsx
@@ -12,7 +12,7 @@ import { store } from "src/store"
 export const FretboardApp: React.FC<RouteComponentProps> = () => {
   return (
     <>
-      <Link to="/intervals">
+      <Link to="/">
         <Posterboard>Fretboard Trainer</Posterboard>
       </Link>
 

--- a/src/apps/fretboard/state/fretboardSettingsState.ts
+++ b/src/apps/fretboard/state/fretboardSettingsState.ts
@@ -1,45 +1,19 @@
 import { Action } from "easy-peasy"
 import { StringRange } from "src/utils/fretboardUtils"
 
-export type AccidentalMode = "naturals" | "flats" | "sharps"
 export type StringFocus = 0 | StringRange
 
 export interface FretboardSettings {
-  accidentalMode: AccidentalMode
-  multipleChoice: boolean
-  isMuted: boolean
-
-  showHint: boolean
-  showNotes: boolean
-  showSettings: boolean
   startingFret: number
   stringFocus: StringFocus
 
-  // Actions
-  setAccidentalMode: Action<FretboardSettings, AccidentalMode>
   setStartingFret: Action<FretboardSettings, number>
   setStringFocus: Action<FretboardSettings, StringFocus>
-
-  toggleHint: Action<FretboardSettings, void>
-  toggleMultipleChoice: Action<FretboardSettings, void>
-  toggleMuted: Action<FretboardSettings, void>
-  toggleNotes: Action<FretboardSettings, void>
-  toggleSettings: Action<FretboardSettings, void>
 }
 
 export const fretboardSettingsState: FretboardSettings = {
-  accidentalMode: "naturals",
-  multipleChoice: true,
-  isMuted: true,
-  showHint: false,
-  showNotes: false,
-  showSettings: true,
   startingFret: 1,
   stringFocus: 0, // 0 is disabled
-
-  setAccidentalMode: (state, payload) => {
-    state.accidentalMode = payload
-  },
 
   setStartingFret: (state, startingFret) => {
     // Octive
@@ -47,30 +21,11 @@ export const fretboardSettingsState: FretboardSettings = {
       // Open string
       startingFret = 0
     }
+
     state.startingFret = startingFret
   },
 
   setStringFocus: (state, stringFocus) => {
     state.stringFocus = stringFocus
-  },
-
-  toggleHint: state => {
-    state.showHint = !state.showHint
-  },
-
-  toggleMultipleChoice: state => {
-    state.multipleChoice = !state.multipleChoice
-  },
-
-  toggleMuted: state => {
-    state.isMuted = !state.isMuted
-  },
-
-  toggleNotes: state => {
-    state.showNotes = !state.showNotes
-  },
-
-  toggleSettings: state => {
-    state.showSettings = !state.showSettings
   },
 }

--- a/src/apps/fretboard/state/fretboardState.ts
+++ b/src/apps/fretboard/state/fretboardState.ts
@@ -47,10 +47,8 @@ export const fretboardState: Fretboard = {
 
   pickAnswer: thunk((actions, selectedNote, { getState, dispatch }) => {
     const {
-      fretboard: {
-        currentNote,
-        settings: { isMuted },
-      },
+      fretboard: { currentNote },
+      settings: { isMuted },
     } = getState()
 
     const isCorrect = isEqual(
@@ -86,11 +84,8 @@ export const fretboardState: Fretboard = {
     const state = getState() as StoreModel
 
     const getNotes = () => {
-      const {
-        accidentalMode,
-        startingFret,
-        stringFocus,
-      } = state.fretboard.settings
+      const { accidentalMode } = state.settings
+      const { startingFret, stringFocus } = state.fretboard.settings
 
       return uniqBy(
         times(4, () => {

--- a/src/apps/intervals/components/Answers.tsx
+++ b/src/apps/intervals/components/Answers.tsx
@@ -69,8 +69,8 @@ export const Answers = _props => {
 }
 
 const HintButton = props => {
-  const { showHint } = useStore(state => state.fretboard.settings)
-  const { toggleHint } = useActions(actions => actions.fretboard.settings)
+  const { showHint } = useStore(state => state.settings)
+  const { toggleHint } = useActions(actions => actions.settings)
 
   return (
     <Box pt={2}>

--- a/src/apps/intervals/state/intervalsState.ts
+++ b/src/apps/intervals/state/intervalsState.ts
@@ -1,6 +1,6 @@
 import { Action, Thunk, thunk } from "easy-peasy"
 import { getNote, Note } from "src/utils/fretboardUtils"
-import { isEqual, sample, shuffle, uniqBy, times } from "lodash"
+import { isEqual, last, sample, shuffle, uniqBy, times } from "lodash"
 import { StoreModel } from "src/store"
 import { IntervalMode } from "./intervalsSettingsState"
 
@@ -44,8 +44,8 @@ export const intervalsState: Intervals = {
     const getIntervals = () => {
       return uniqBy(
         times(4, () => {
-          return pickStaticInterval("intermediate")
-          // return pickRandomInterval()
+          // return pickStaticInterval("intermediate")
+          return pickRandomInterval()
         }),
         "label"
       )
@@ -70,7 +70,8 @@ export const intervalsState: Intervals = {
 
 // Helpers
 
-type IntervalLabels =
+export type IntervalLabels =
+  | "1"
   | "unison"
   | "minor 2nd"
   | "♭2"
@@ -82,6 +83,7 @@ type IntervalLabels =
   | "3"
   | "perfect 4th"
   | "4"
+  | "♭5"
   | "dim 5th"
   | "aug 4th"
   | "♭4"
@@ -96,6 +98,7 @@ type IntervalLabels =
   | "minor 7th"
   | "♭7"
   | "major 7th"
+  | "7"
   | "octave"
 
 type IntervalRange = [Note, Note]
@@ -153,7 +156,7 @@ export const basicIntervals: Interval[] = [
   },
   {
     ...getInterval([[6, 1], [5, 2]]),
-    label: ["dim 5th", "aug 4th"],
+    label: ["dim 5th", "aug 4th", "♭5"],
   },
   {
     ...getInterval([[6, 1], [5, 3]]),
@@ -169,11 +172,11 @@ export const basicIntervals: Interval[] = [
   },
   {
     ...getInterval([[6, 1], [5, 5]]),
-    label: ["major 6th"],
+    label: ["major 6th", "6"],
   },
   {
     ...getInterval([[6, 3], [4, 2]]),
-    label: ["major 6th"],
+    label: ["major 6th", "6"],
   },
   {
     ...getInterval([[6, 1], [4, 1]]),
@@ -181,7 +184,7 @@ export const basicIntervals: Interval[] = [
   },
   {
     ...getInterval([[6, 1], [4, 2]]),
-    label: ["major 7th"],
+    label: ["major 7th", "7"],
   },
   {
     ...getInterval([[6, 1], [4, 3]]),
@@ -200,23 +203,23 @@ export const basicIntervals: Interval[] = [
 export const complexIntervals: Interval[] = [
   {
     ...getInterval([[4, 3], [2, 1]]),
-    label: ["perfect 5th"],
+    label: ["perfect 5th", "5"],
   },
   {
     ...getInterval([[4, 3], [2, 2]]),
-    label: ["minor 6th", "aug 5th"],
+    label: ["minor 6th", "aug 5th", "♭6"],
   },
   {
     ...getInterval([[4, 3], [2, 3]]),
-    label: ["major 6th"],
+    label: ["major 6th", "6"],
   },
   {
     ...getInterval([[4, 3], [2, 4]]),
-    label: ["minor 7th"],
+    label: ["minor 7th", "♭7"],
   },
   {
     ...getInterval([[4, 3], [2, 5]]),
-    label: ["major 7th"],
+    label: ["major 7th", "7"],
   },
   {
     ...getInterval([[4, 2], [2, 5]]),
@@ -232,51 +235,51 @@ export const complexIntervals: Interval[] = [
   },
   {
     ...getInterval([[3, 4], [2, 1]]),
-    label: ["minor 2nd"],
+    label: ["minor 2nd", "♭2"],
   },
   {
     ...getInterval([[3, 5], [2, 3]]),
-    label: ["major 2nd"],
+    label: ["major 2nd", "2"],
   },
   {
     ...getInterval([[3, 4], [2, 3]]),
-    label: ["minor 3rd"],
+    label: ["minor 3rd", "♭3"],
   },
   {
     ...getInterval([[3, 4], [2, 4]]),
-    label: ["major 3rd"],
+    label: ["major 3rd", "3"],
   },
   {
     ...getInterval([[3, 2], [2, 3]]),
-    label: ["perfect 4th"],
+    label: ["perfect 4th", "4"],
   },
   {
     ...getInterval([[3, 2], [2, 4]]),
-    label: ["dim 5th", "aug 4th"],
+    label: ["dim 5th", "aug 4th", "♭5"],
   },
   {
     ...getInterval([[3, 2], [2, 5]]),
-    label: ["perfect 5th"],
+    label: ["perfect 5th", "5"],
   },
   {
     ...getInterval([[3, 5], [1, 3]]),
-    label: ["perfect 5th"],
+    label: ["perfect 5th", "5"],
   },
   {
     ...getInterval([[3, 2], [1, 1]]),
-    label: ["minor 6th", "dim 5th"],
+    label: ["minor 6th", "dim 5th", "♭6"],
   },
   {
     ...getInterval([[3, 2], [1, 2]]),
-    label: ["major 6th"],
+    label: ["major 6th", "6"],
   },
   {
     ...getInterval([[3, 2], [1, 3]]),
-    label: ["minor 7th"],
+    label: ["minor 7th", "♭7"],
   },
   {
     ...getInterval([[3, 2], [1, 4]]),
-    label: ["major 7th"],
+    label: ["major 7th", "7"],
   },
   {
     ...getInterval([[3, 2], [1, 5]]),
@@ -345,6 +348,10 @@ export function pickRandomInterval(): Interval {
   if (!interval) {
     return pickRandomInterval()
   }
+
+  // TODO: Add non-root relative intervals
+  note1.interval = "1"
+  note2.interval = last(interval.label)
 
   return {
     ...interval,

--- a/src/apps/settings/components/Settings.tsx
+++ b/src/apps/settings/components/Settings.tsx
@@ -8,16 +8,16 @@ import { CycleButton } from "src/components/ui/CycleButton"
 import { SettingsContainer } from "src/components/ui/SettingsContainer"
 
 export const Settings = () => {
+  const { setStartingFret, setStringFocus } = useActions(
+    actions => actions.fretboard.settings
+  )
+
   const {
     setAccidentalMode,
     toggleMultipleChoice,
     toggleNotes,
     toggleSettings,
   } = useActions(actions => actions.settings)
-
-  const { setStartingFret, setStringFocus } = useActions(
-    actions => actions.fretboard.settings
-  )
 
   const { accidentalMode, multipleChoice, showNotes, showSettings } = useStore(
     state => state.settings

--- a/src/apps/settings/index.tsx
+++ b/src/apps/settings/index.tsx
@@ -1,1 +1,1 @@
-export const settings = {}
+export * from "./components/Settings"

--- a/src/apps/settings/state/index.tsx
+++ b/src/apps/settings/state/index.tsx
@@ -1,0 +1,1 @@
+export * from "./settingsState"

--- a/src/apps/settings/state/settingsState.tsx
+++ b/src/apps/settings/state/settingsState.tsx
@@ -1,0 +1,53 @@
+import { Action } from "easy-peasy"
+
+export type AccidentalMode = "naturals" | "flats" | "sharps"
+
+export interface SettingsModel {
+  accidentalMode: AccidentalMode
+  isMuted: boolean
+  multipleChoice: boolean
+  showHint: boolean
+  showNotes: boolean
+  showSettings: boolean
+
+  setAccidentalMode: Action<SettingsModel, AccidentalMode>
+
+  toggleHint: Action<SettingsModel, void>
+  toggleMultipleChoice: Action<SettingsModel, void>
+  toggleMuted: Action<SettingsModel, void>
+  toggleNotes: Action<SettingsModel, void>
+  toggleSettings: Action<SettingsModel, void>
+}
+
+export const settingsState: SettingsModel = {
+  accidentalMode: "naturals",
+  isMuted: true,
+  multipleChoice: true,
+  showHint: false,
+  showNotes: false,
+  showSettings: true,
+
+  setAccidentalMode: (state, payload) => {
+    state.accidentalMode = payload
+  },
+
+  toggleHint: state => {
+    state.showHint = !state.showHint
+  },
+
+  toggleMultipleChoice: state => {
+    state.multipleChoice = !state.multipleChoice
+  },
+
+  toggleMuted: state => {
+    state.isMuted = !state.isMuted
+  },
+
+  toggleNotes: state => {
+    state.showNotes = !state.showNotes
+  },
+
+  toggleSettings: state => {
+    state.showSettings = !state.showSettings
+  },
+}

--- a/src/components/Fretboard/Fretboard.tsx
+++ b/src/components/Fretboard/Fretboard.tsx
@@ -10,11 +10,8 @@ import { notes, containsSharpOrFlat, getNote } from "src/utils/fretboardUtils"
 import { color } from "src/Theme"
 
 export const Fretboard = _props => {
-  const { showHint, showNotes } = useStore(state => state.fretboard.settings) // prettier-ignore
-  const {
-    settings: { accidentalMode },
-    currentNote,
-  } = useStore(state => state.fretboard)
+  const { accidentalMode, showHint, showNotes } = useStore(state => state.settings) // prettier-ignore
+  const { currentNote } = useStore(state => state.fretboard)
 
   const fretboard = notes[accidentalMode]
 

--- a/src/components/Fretboard/Fretboard2.tsx
+++ b/src/components/Fretboard/Fretboard2.tsx
@@ -1,54 +1,52 @@
 import React from "react"
-import styled from "styled-components"
+import styled, { css } from "styled-components"
 import { Box, Flex } from "rebass"
-import fretboardGraphic from "src/assets/fretboard.jpg"
-import { useStore } from "src/utils/hooks"
-import { notes, Note as NoteProps } from "src/utils/fretboardUtils"
-import { Display } from "../ui/Typography"
 import { isEqual } from "lodash"
+
+import fretboardGraphic from "src/assets/fretboard.jpg"
+import { notes, Note as NoteProps } from "src/utils/fretboardUtils"
+import { Display } from "src/components/ui/Typography"
+import { AccidentalMode } from "src/apps/fretboard/state/fretboardSettingsState"
 
 interface FretboardProps {
   selectedNotes: NoteProps[]
+  accidentalMode?: AccidentalMode
+  isVisible?: (props?) => boolean
 }
 
-export const Fretboard2: React.FC<FretboardProps> = ({ selectedNotes }) => {
+export const Fretboard2: React.FC<FretboardProps> = props => {
   const {
-    settings: { accidentalMode },
-  } = useStore(state => state.fretboard)
+    selectedNotes,
+    accidentalMode = "flats",
+    isVisible = () => true,
+  } = props
 
   const fretboard = notes[accidentalMode]
 
   return (
     <FretboardContainer>
       {fretboard.map((string, stringIndex) => {
-        let lastPos = 0
+        const updatePosition = computeNotePosition()
+
         return (
           <Flex key={stringIndex}>
             {string.map((note, noteIndex) => {
-              const base = 135
-              let space = base + lastPos - (base / 12) * (noteIndex * 0.5)
-              lastPos = space
-              space -= 167
+              const notePosition = updatePosition(stringIndex, noteIndex)
 
-              const foundMatch = selectedNotes.some(n => {
+              const currentNote = selectedNotes.find(n => {
                 const match = isEqual([stringIndex, noteIndex], n.position)
                 return match
               })
 
+              const visible = isVisible({
+                ...props,
+                currentNote,
+              })
+
               return (
-                <NoteContainer
-                  key={noteIndex}
-                  style={{
-                    left: space,
-                    top: 15 + stringIndex * 40,
-                  }}
-                >
-                  <Note
-                    style={{
-                      backgroundColor: foundMatch ? "green" : "",
-                    }}
-                  >
-                    <Display>1</Display>
+                <NoteContainer key={noteIndex} style={notePosition}>
+                  <Note selected={Boolean(currentNote)} visible={visible}>
+                    <Display>{note}</Display>
                   </Note>
                 </NoteContainer>
               )
@@ -65,25 +63,55 @@ const FretboardContainer = styled(Box)`
   background-size: 100% 100%;
   height: 260px;
   position: relative;
+`
 
-  pointer-events: none;
+const noteSize = css`
+  width: 30px;
+  height: 30px;
 `
 
 const NoteContainer = styled(Box)`
   position: absolute;
-  width: 100%;
-  height: 100%;
+  ${noteSize};
 `
 
-const Note = styled(Flex)`
+const Note = styled(Flex)<{
+  selected?: boolean
+  visible?: boolean
+}>`
   border-radius: 50%;
-  text-shadow: 4px 4px 6px rgba(0, 0, 0, 0.6);
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.3);
-  position: absolute;
-  width: 30px;
-  height: 30px;
-  background: rgba(255, 255, 255, 0.1);
+
+  background-color: rgba(255, 255, 255, 0.1);
+  background-color: ${p => (p.selected ? "green" : "")};
   color: white;
-  justify-content: center;
+
+  ${noteSize};
+
   align-items: center;
+  justify-content: center;
+  position: absolute;
+
+  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.3);
+  text-shadow: 4px 4px 6px rgba(0, 0, 0, 0.6);
+
+  visibility: ${p => (p.visible ? "visible" : "hidden")};
 `
+
+// Helpers
+
+/**
+ * TODO: Make this dynamic based upon the width of the fretboard
+ */
+function computeNotePosition(lastPos: number = 0) {
+  return (stringIndex: number, noteIndex: number) => {
+    const base = 135
+    let left = base + lastPos - (base / 12) * (noteIndex * 0.5)
+    lastPos = left
+    left -= 167
+    const top = 15 + stringIndex * 40
+    return {
+      left,
+      top,
+    }
+  }
+}

--- a/src/components/Fretboard/Fretboard2.tsx
+++ b/src/components/Fretboard/Fretboard2.tsx
@@ -6,7 +6,7 @@ import { isEqual } from "lodash"
 import fretboardGraphic from "src/assets/fretboard.jpg"
 import { notes, Note as NoteProps } from "src/utils/fretboardUtils"
 import { Display } from "src/components/ui/Typography"
-import { AccidentalMode } from "src/apps/fretboard/state/fretboardSettingsState"
+import { AccidentalMode } from "src/apps/settings/state"
 
 interface FretboardProps {
   selectedNotes: NoteProps[]

--- a/src/components/Scoreboard/scoreboardState.tsx
+++ b/src/components/Scoreboard/scoreboardState.tsx
@@ -35,10 +35,10 @@ export const scoreboard: ScoreboardModel = {
     actions.setFlashMessage(flashMessage)
 
     // TODO: Move hint toggling to a listener inside of fretboardState
-    dispatch.fretboard.settings.toggleHint()
+    dispatch.settings.toggleHint()
     setTimeout(() => {
       actions.setFlashMessage("")
-      dispatch.fretboard.settings.toggleHint()
+      dispatch.settings.toggleHint()
     }, 2000)
   }),
 }

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -4,6 +4,7 @@ import { save, load } from "redux-localstorage-simple"
 
 import { fretboard, FretboardModel } from "src/apps/fretboard/state"
 import { intervals, IntervalsModel } from "./apps/intervals/state"
+import { settingsState as settings, SettingsModel } from "./apps/settings/state"
 
 import {
   scoreboard,
@@ -15,17 +16,21 @@ const STORAGE_SETTINGS = {
   states: ["fretboard.settings"],
 }
 
+// Define modules
 export interface StoreModel {
   fretboard: FretboardModel
   intervals: IntervalsModel
   scoreboard: ScoreboardModel
+  settings: SettingsModel
 }
 
+// Build store
 export const store = createStore<StoreModel, EasyPeasyConfig>(
   {
     fretboard,
     intervals,
     scoreboard,
+    settings,
   },
   {
     middleware: [

--- a/src/utils/fretboardUtils.ts
+++ b/src/utils/fretboardUtils.ts
@@ -4,6 +4,7 @@ import {
 } from "src/apps/fretboard/state/fretboardSettingsState"
 
 import { isEmpty, random } from "lodash"
+import { IntervalLabels } from "src/apps/intervals/state/intervalsState"
 
 // TODO:
 // Surely this map can be done dynamically based upon empty slots in the
@@ -45,6 +46,7 @@ export interface Note {
   note: string
   string?: GuitarString
   position: NotePosition
+  interval?: IntervalLabels
 }
 
 /**

--- a/src/utils/fretboardUtils.ts
+++ b/src/utils/fretboardUtils.ts
@@ -1,10 +1,8 @@
-import {
-  AccidentalMode,
-  StringFocus,
-} from "src/apps/fretboard/state/fretboardSettingsState"
-
 import { isEmpty, random } from "lodash"
+
+import { StringFocus } from "src/apps/fretboard/state/fretboardSettingsState"
 import { IntervalLabels } from "src/apps/intervals/state/intervalsState"
+import { AccidentalMode } from "src/apps/settings/state"
 
 // TODO:
 // Surely this map can be done dynamically based upon empty slots in the


### PR DESCRIPTION
A lot of settings that should be global were stored under the notes app. This moves things global to so that they can be shared. 