### PR TITLE
Fix root note / localStorage path

### DIFF
--- a/src/components/Fretboard/Fretboard.tsx
+++ b/src/components/Fretboard/Fretboard.tsx
@@ -57,7 +57,7 @@ export const Fretboard = _props => {
                     mr={SPACE}
                     key={noteIndex}
                     isCurrentNote={showNote || isCurrentNote}
-                    isRoot={showNote && note === currentNote.note}
+                    isRoot={!showHint && showNote && note === currentNote.note}
                     showNote={showNote}
                   >
                     <Note

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -13,7 +13,7 @@ import {
 
 const STORAGE_SETTINGS = {
   namespace: "fretboard-trainer",
-  states: ["fretboard.settings"],
+  states: ["notes.settings", "settings"],
 }
 
 // Define modules


### PR DESCRIPTION
Fixes issue with localStorage path (`fretboard.settings` -> `settings`), as well as the red root note when a correct answer is selected. 