### PR TITLE
[Refactor] Rename accidentalMode -> fretboardMode

### DIFF
--- a/src/apps/intervals/NoteRenderer.tsx
+++ b/src/apps/intervals/NoteRenderer.tsx
@@ -12,7 +12,6 @@ export const NoteRenderer: React.FC<NoteRendererProps> = ({
   stringIndex,
   noteIndex,
   noteLabel,
-  // note,
 }) => {
   const { currentInterval } = useStore(state => state.intervals)
 
@@ -25,7 +24,7 @@ export const NoteRenderer: React.FC<NoteRendererProps> = ({
     })
   })
 
-  const { accidentalMode, showHint, showNotes } = useStore(
+  const { fretboardMode, showHint, showNotes } = useStore(
     state => state.settings
   )
 
@@ -33,7 +32,7 @@ export const NoteRenderer: React.FC<NoteRendererProps> = ({
     switch (true) {
       case showNotes: {
         return (
-          getNoteVisibiltyForSetting(accidentalMode, noteLabel) &&
+          getNoteVisibiltyForSetting(fretboardMode, noteLabel) &&
           Boolean(noteLabel)
         )
       }
@@ -67,7 +66,7 @@ export const NoteRenderer: React.FC<NoteRendererProps> = ({
     note => {
       switch (true) {
         case showNotes: {
-          if (accidentalMode === "intervals") {
+          if (fretboardMode === "intervals") {
             return noteLabel === "1"
           }
           return noteLabel === currentInterval.notes[0].note
@@ -86,7 +85,7 @@ export const NoteRenderer: React.FC<NoteRendererProps> = ({
 
   return (
     <FretboardNote
-      accidentalMode={accidentalMode}
+      fretboardMode={fretboardMode}
       width={size}
       height={size}
       selected={Boolean(currentNote)}

--- a/src/apps/intervals/NoteRenderer.tsx
+++ b/src/apps/intervals/NoteRenderer.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-
 import React from "react"
 import { Display } from "src/components/ui/Typography"
 import { NoteRendererProps } from "src/components/Fretboard/Fretboard"
@@ -7,6 +5,7 @@ import { isEqual } from "lodash"
 import { get } from "src/utils/get"
 import { useStore } from "src/utils/hooks"
 import { getNoteVisibiltyForSetting } from "src/utils/fretboard/getNoteVisibility"
+import { Note } from "src/utils/types"
 
 export const NoteRenderer: React.FC<NoteRendererProps> = ({
   FretboardNote,
@@ -17,8 +16,9 @@ export const NoteRenderer: React.FC<NoteRendererProps> = ({
 }) => {
   const { currentInterval } = useStore(state => state.intervals)
 
-  // FIXME: Initialze interval before first render
-  const currentNote = get(currentInterval, p => {
+  // TODO: Figure out how to deal with value | undefined from `find`
+  // @ts-ignore
+  const currentNote: Note = get(currentInterval, p => {
     return p.notes.find(n => {
       const match = isEqual([stringIndex, noteIndex], n.position)
       return match
@@ -45,14 +45,14 @@ export const NoteRenderer: React.FC<NoteRendererProps> = ({
 
   const label = get(
     currentNote,
-    p => {
+    note => {
       switch (true) {
         case showNotes:
           return noteLabel
         case showHint:
-          return p!.interval
-        case p!.interval === "1":
-          return p!.interval
+          return note.interval
+        case note.interval === "1":
+          return note.interval
         default:
           return ""
       }
@@ -60,11 +60,11 @@ export const NoteRenderer: React.FC<NoteRendererProps> = ({
     ""
   )
 
-  const isInterval = get(currentNote, p => p!.interval !== "1")
+  const isInterval = get(currentNote, note => note.interval !== "1")
 
   const isRoot = get(
     currentNote,
-    p => {
+    note => {
       switch (true) {
         case showNotes: {
           if (accidentalMode === "intervals") {
@@ -72,9 +72,8 @@ export const NoteRenderer: React.FC<NoteRendererProps> = ({
           }
           return noteLabel === currentInterval.notes[0].note
         }
-        case p!.interval === "1":
+        case note.interval === "1":
           return true
-
         default:
           return false
       }

--- a/src/apps/intervals/NoteRenderer.tsx
+++ b/src/apps/intervals/NoteRenderer.tsx
@@ -67,6 +67,9 @@ export const NoteRenderer: React.FC<NoteRendererProps> = ({
     p => {
       switch (true) {
         case showNotes: {
+          if (accidentalMode === "intervals") {
+            return noteLabel === "1"
+          }
           return noteLabel === currentInterval.notes[0].note
         }
         case p!.interval === "1":
@@ -84,6 +87,7 @@ export const NoteRenderer: React.FC<NoteRendererProps> = ({
 
   return (
     <FretboardNote
+      accidentalMode={accidentalMode}
       width={size}
       height={size}
       selected={Boolean(currentNote)}

--- a/src/apps/intervals/index.tsx
+++ b/src/apps/intervals/index.tsx
@@ -9,17 +9,11 @@ import { Answers } from "src/apps/intervals/Answers"
 import { store } from "src/store"
 import { Settings } from "src/apps/settings/Settings"
 import { NoteRenderer } from "./NoteRenderer"
-import { useStore } from "src/utils/hooks"
 
 export const IntervalsApp: React.FC<RouteComponentProps> = () => {
   useEffect(() => {
     store.dispatch.intervals.pickRandomInterval()
   }, [])
-
-  const { currentInterval } = useStore(state => state.intervals)
-  if (!currentInterval) {
-    return null
-  }
 
   return (
     <>

--- a/src/apps/notes/NoteRenderer.tsx
+++ b/src/apps/notes/NoteRenderer.tsx
@@ -8,7 +8,7 @@ import { getNoteVisibiltyForSetting } from "src/utils/fretboard/getNoteVisibilit
 
 export const NoteRenderer: React.FC<NoteRendererProps> = props => {
   const { FretboardNote, noteLabel, stringIndex, noteIndex } = props
-  const { accidentalMode, showHint, showNotes } = useStore(state => state.settings) // prettier-ignore
+  const { fretboardMode, showHint, showNotes } = useStore(state => state.settings) // prettier-ignore
   const { currentNote } = useStore(state => state.notes)
   const isCurrentNote = isEqual(currentNote.position, [stringIndex, noteIndex])
 
@@ -16,7 +16,7 @@ export const NoteRenderer: React.FC<NoteRendererProps> = props => {
     switch (true) {
       case showNotes: {
         return (
-          getNoteVisibiltyForSetting(accidentalMode, noteLabel) &&
+          getNoteVisibiltyForSetting(fretboardMode, noteLabel) &&
           Boolean(noteLabel)
         ) // FIXME: remove falsy note value
       }
@@ -35,7 +35,7 @@ export const NoteRenderer: React.FC<NoteRendererProps> = props => {
       selected={isCurrentNote}
       visible={showLabel}
       isRoot={isRoot}
-      accidentalMode={accidentalMode}
+      fretboardMode={fretboardMode}
     >
       {showLabel && <Display>{noteLabel}</Display>}
     </FretboardNote>

--- a/src/apps/notes/NoteRenderer.tsx
+++ b/src/apps/notes/NoteRenderer.tsx
@@ -31,7 +31,12 @@ export const NoteRenderer: React.FC<NoteRendererProps> = props => {
   const isRoot = !showHint && showLabel && noteLabel === currentNote.note
 
   return (
-    <FretboardNote selected={isCurrentNote} visible={showLabel} isRoot={isRoot}>
+    <FretboardNote
+      selected={isCurrentNote}
+      visible={showLabel}
+      isRoot={isRoot}
+      accidentalMode={accidentalMode}
+    >
       {showLabel && <Display>{noteLabel}</Display>}
     </FretboardNote>
   )

--- a/src/apps/notes/state/notesState.ts
+++ b/src/apps/notes/state/notesState.ts
@@ -85,13 +85,13 @@ export const notesState: Fretboard = {
     const state = getState() as StoreModel
 
     const getNotes = () => {
-      const { accidentalMode } = state.settings
+      const { fretboardMode } = state.settings
       const { startingFret, stringFocus } = state.notes.settings
 
       return uniqBy(
         times(4, () => {
           return getNote({
-            accidentalMode,
+            fretboardMode,
             startingFret,
             stringFocus,
           })

--- a/src/apps/settings/Settings.tsx
+++ b/src/apps/settings/Settings.tsx
@@ -56,6 +56,8 @@ export const Settings = () => {
                     return 1
                   case "sharps":
                     return 2
+                  case "intervals":
+                    return 3
                 }
               }}
               items={[
@@ -70,6 +72,10 @@ export const Settings = () => {
                 {
                   label: "Sharps",
                   onSelect: () => setAccidentalMode("sharps"),
+                },
+                {
+                  label: "Intervals",
+                  onSelect: () => setAccidentalMode("intervals"),
                 },
               ]}
             />

--- a/src/apps/settings/Settings.tsx
+++ b/src/apps/settings/Settings.tsx
@@ -13,13 +13,13 @@ export const Settings = () => {
   )
 
   const {
-    setAccidentalMode,
+    setFretboardMode,
     toggleMultipleChoice,
     toggleNotes,
     toggleSettings,
   } = useActions(actions => actions.settings)
 
-  const { accidentalMode, multipleChoice, showNotes, showSettings } = useStore(
+  const { fretboardMode, multipleChoice, showNotes, showSettings } = useStore(
     state => state.settings
   )
 
@@ -49,7 +49,7 @@ export const Settings = () => {
             />
             <CycleButton
               index={() => {
-                switch (accidentalMode) {
+                switch (fretboardMode) {
                   case "naturals":
                     return 0
                   case "flats":
@@ -63,19 +63,19 @@ export const Settings = () => {
               items={[
                 {
                   label: "Natural notes only",
-                  onSelect: () => setAccidentalMode("naturals"),
+                  onSelect: () => setFretboardMode("naturals"),
                 },
                 {
                   label: "Flats",
-                  onSelect: () => setAccidentalMode("flats"),
+                  onSelect: () => setFretboardMode("flats"),
                 },
                 {
                   label: "Sharps",
-                  onSelect: () => setAccidentalMode("sharps"),
+                  onSelect: () => setFretboardMode("sharps"),
                 },
                 {
                   label: "Intervals",
-                  onSelect: () => setAccidentalMode("intervals"),
+                  onSelect: () => setFretboardMode("intervals"),
                 },
               ]}
             />

--- a/src/apps/settings/settingsState.tsx
+++ b/src/apps/settings/settingsState.tsx
@@ -1,8 +1,8 @@
 import { Action } from "easy-peasy"
-import { AccidentalMode } from "src/utils/types"
+import { FretboardMode } from "src/utils/types"
 
 export interface SettingsModel {
-  accidentalMode: AccidentalMode
+  fretboardMode: FretboardMode
   isMuted: boolean
   multipleChoice: boolean
   showHint: boolean
@@ -10,7 +10,7 @@ export interface SettingsModel {
   showNotes: boolean
   showSettings: boolean
 
-  setAccidentalMode: Action<SettingsModel, AccidentalMode>
+  setFretboardMode: Action<SettingsModel, FretboardMode>
 
   toggleHint: Action<SettingsModel, void>
   toggleIntervals: Action<SettingsModel, void>
@@ -21,7 +21,7 @@ export interface SettingsModel {
 }
 
 export const settingsState: SettingsModel = {
-  accidentalMode: "naturals",
+  fretboardMode: "naturals",
   isMuted: true,
   multipleChoice: true,
   showHint: false,
@@ -29,8 +29,8 @@ export const settingsState: SettingsModel = {
   showNotes: false,
   showSettings: true,
 
-  setAccidentalMode: (state, payload) => {
-    state.accidentalMode = payload
+  setFretboardMode: (state, payload) => {
+    state.fretboardMode = payload
   },
 
   toggleHint: state => {

--- a/src/components/Fretboard/Fretboard.tsx
+++ b/src/components/Fretboard/Fretboard.tsx
@@ -95,6 +95,7 @@ export interface FretboardNoteProps
   extends WidthProps,
     HeightProps,
     BackgroundProps {
+  accidentalMode: AccidentalMode
   isRoot?: boolean
   isInterval?: boolean
   selected: boolean
@@ -156,11 +157,21 @@ const FretboardNote = styled(Flex)<FretboardNoteProps>`
 
   ${background};
 
-  /* Align inner text content, ignoring accidental */
-  justify-content: flex-start;
-  > div {
-    margin-left: 9px;
-  }
+  ${props => {
+    if (props.accidentalMode === "intervals") {
+      return css`
+        justify-content: center;
+      `
+    } else {
+      /* Align inner text content, ignoring accidental */
+      return css`
+        justify-content: flex-start;
+        > div {
+          margin-left: 9px;
+        }
+      `
+    }
+  }}
 
   /* TODO: Move this animation out of CSS */
   animation-name: ${p => (p.visible || p.selected ? "fadeInNote" : "none")};

--- a/src/components/Fretboard/Fretboard.tsx
+++ b/src/components/Fretboard/Fretboard.tsx
@@ -13,7 +13,7 @@ import {
   background,
   BackgroundProps,
 } from "styled-system"
-import { AccidentalMode, Note } from "src/utils/types"
+import { FretboardMode, Note } from "src/utils/types"
 import { getFretboard } from "src/utils/fretboard/getFretboard"
 
 export interface NoteRendererProps {
@@ -31,8 +31,8 @@ interface FretboardProps {
 }
 
 export const Fretboard: React.FC<FretboardProps> = props => {
-  const { accidentalMode } = useStore(state => state.settings)
-  const fretboard = getFretboard(accidentalMode)
+  const { fretboardMode } = useStore(state => state.settings)
+  const fretboard = getFretboard(fretboardMode)
 
   return (
     <FretboardContainer>
@@ -47,7 +47,7 @@ export const Fretboard: React.FC<FretboardProps> = props => {
               const note = lookupNote({
                 stringIndex,
                 noteIndex: 0,
-                accidentalMode,
+                fretboardMode,
               })
 
               return (
@@ -55,7 +55,7 @@ export const Fretboard: React.FC<FretboardProps> = props => {
                   key={noteIndex}
                   style={notePosition}
                   onClick={() =>
-                    logNote({ stringIndex, noteIndex, accidentalMode })
+                    logNote({ stringIndex, noteIndex, fretboardMode })
                   }
                 >
                   {props.renderNote({
@@ -95,7 +95,7 @@ export interface FretboardNoteProps
   extends WidthProps,
     HeightProps,
     BackgroundProps {
-  accidentalMode: AccidentalMode
+  fretboardMode: FretboardMode
   isRoot?: boolean
   isInterval?: boolean
   selected: boolean
@@ -158,7 +158,7 @@ const FretboardNote = styled(Flex)<FretboardNoteProps>`
   ${background};
 
   ${props => {
-    if (props.accidentalMode === "intervals") {
+    if (props.fretboardMode === "intervals") {
       return css`
         justify-content: center;
       `
@@ -201,14 +201,14 @@ const FretboardNote = styled(Flex)<FretboardNoteProps>`
 interface NoteLookupProps {
   stringIndex: number
   noteIndex: number
-  accidentalMode: AccidentalMode
+  fretboardMode: FretboardMode
 }
 
 function lookupNote(props: NoteLookupProps): Note {
-  const { stringIndex, noteIndex, accidentalMode } = props
+  const { stringIndex, noteIndex, fretboardMode } = props
   const noteLookup: any = [stringIndex + 1, noteIndex]
   const note = getNote({
-    accidentalMode,
+    fretboardMode,
     position: noteLookup,
   })
   return note

--- a/src/utils/fretboard/getFretboard.ts
+++ b/src/utils/fretboard/getFretboard.ts
@@ -1,8 +1,14 @@
 import { AccidentalMode } from "../types"
+import { getIntervals } from "./getIntervals"
 
 export function getFretboard(
   accidentalMode: AccidentalMode = "flats"
 ): string[][] {
+  if (accidentalMode === "intervals") {
+    const intervals = getIntervals()
+    return intervals
+  }
+
   const fretboard = [
     ["E", "F", "", "G", "", "A", "", "B", "C", "", "D", "", "E"],
     ["B", "C", "", "D", "", "E", "F", "", "G", "", "A", "", "B"],

--- a/src/utils/fretboard/getFretboard.ts
+++ b/src/utils/fretboard/getFretboard.ts
@@ -1,10 +1,10 @@
-import { AccidentalMode } from "../types"
+import { FretboardMode } from "../types"
 import { getIntervals } from "./getIntervals"
 
 export function getFretboard(
-  accidentalMode: AccidentalMode = "flats"
+  fretboardMode: FretboardMode = "flats"
 ): string[][] {
-  if (accidentalMode === "intervals") {
+  if (fretboardMode === "intervals") {
     const intervals = getIntervals()
     return intervals
   }
@@ -21,7 +21,7 @@ export function getFretboard(
       if (note) {
         return note
       } else {
-        switch (accidentalMode) {
+        switch (fretboardMode) {
           case "flats":
             return string[noteIndex + 1] + "♭"
           case "sharps":

--- a/src/utils/fretboard/getIntervals.ts
+++ b/src/utils/fretboard/getIntervals.ts
@@ -6,7 +6,7 @@ export function getIntervals() {
   const fretboardNotes = getFretboard("flats")
 
   const note = getNote({
-    accidentalMode: "flats",
+    fretboardMode: "flats",
     position: [1, 1],
   })
 

--- a/src/utils/fretboard/getNote.ts
+++ b/src/utils/fretboard/getNote.ts
@@ -2,7 +2,7 @@ import { containsSharpOrFlat } from "./containsSharpOrFlat"
 import { getString } from "./getString"
 import { isEmpty, random } from "lodash"
 import { StringFocus } from "src/apps/notes/state/notesSettingsState"
-import { NotePosition, AccidentalMode, Note } from "../types"
+import { NotePosition, FretboardMode, Note } from "../types"
 import { getFretboard } from "./getFretboard"
 
 /**
@@ -15,14 +15,14 @@ import { getFretboard } from "./getFretboard"
  */
 export function getNote(
   props: {
-    accidentalMode?: AccidentalMode
+    fretboardMode?: FretboardMode
     position?: NotePosition
     startingFret?: number
     stringFocus?: StringFocus
   } = {}
 ): Note {
   const {
-    accidentalMode = "flats",
+    fretboardMode = "flats",
     position,
     startingFret = 1,
     stringFocus = 0,
@@ -44,10 +44,10 @@ export function getNote(
   const stringName = getString(string)
   string--
 
-  const noteName = getFretboard(accidentalMode)[string][note]
+  const noteName = getFretboard(fretboardMode)[string][note]
 
   // Re-run function if we return an invalid result
-  const showAccidentals = accidentalMode !== "naturals"
+  const showAccidentals = fretboardMode !== "naturals"
   if (
     (!showAccidentals && containsSharpOrFlat(noteName)) ||
     isEmpty(noteName)

--- a/src/utils/fretboard/getNoteVisibility.ts
+++ b/src/utils/fretboard/getNoteVisibility.ts
@@ -1,15 +1,15 @@
 import { containsSharpOrFlat } from "./containsSharpOrFlat"
-import { AccidentalMode } from "../types"
+import { FretboardMode } from "../types"
 
 /**
  * When selecting "Show Notes" from the settings menu we need to check if
  * "naturals" is selected, and if so, hide all sharps and flats.
  */
 export function getNoteVisibiltyForSetting(
-  accidentalMode: AccidentalMode,
+  fretboardMode: FretboardMode,
   note: string
 ): boolean {
-  if (accidentalMode === "naturals") {
+  if (fretboardMode === "naturals") {
     if (containsSharpOrFlat(note)) {
       return false
     }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -26,7 +26,7 @@ export type ScaleNote =
   | "B♭"
   | "B"
 
-export type AccidentalMode = "naturals" | "flats" | "sharps" | "intervals"
+export type FretboardMode = "naturals" | "flats" | "sharps" | "intervals"
 
 export type IntervalLabels =
   | "1"

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -26,7 +26,7 @@ export type ScaleNote =
   | "B♭"
   | "B"
 
-export type AccidentalMode = "naturals" | "flats" | "sharps"
+export type AccidentalMode = "naturals" | "flats" | "sharps" | "intervals"
 
 export type IntervalLabels =
   | "1"
@@ -74,11 +74,28 @@ export const intervalList: Partial<IntervalLabels>[] = [
   "♭3",
   "3",
   "4",
-  "#4/♭5",
+  "♭5",
   "5",
-  "#5/♭6",
+  "♭6",
   "6",
   "♭7",
   "7",
   "1",
 ]
+
+// TODO: Handle sharps and flats in design
+// export const intervalList: Partial<IntervalLabels>[] = [
+//   "1",
+//   "♭2",
+//   "2",
+//   "♭3",
+//   "3",
+//   "4",
+//   "#4/♭5",
+//   "5",
+//   "#5/♭6",
+//   "6",
+//   "♭7",
+//   "7",
+//   "1",
+// ]


### PR DESCRIPTION
Renames `accidentalMode` to `fretboardMode` to account for new `intervals` option. 