### PR TITLE
[Intervals] Add string focus

### DIFF
--- a/src/apps/intervals/IntervalSettings.tsx
+++ b/src/apps/intervals/IntervalSettings.tsx
@@ -2,16 +2,21 @@ import React from "react"
 import { useActions, useStore } from "src/utils/hooks"
 import { Settings } from "../settings/Settings"
 import { Select } from "src/components/ui/Select"
+import { StringRange } from "src/utils/types"
 
 export const IntervalsSettings = () => {
-  const { intervalMode } = useStore(state => state.intervals.settings)
-  const { setIntervalMode } = useActions(actions => actions.intervals.settings)
+  const { intervalMode, stringFocus } = useStore(
+    state => state.intervals.settings
+  )
+  const { setIntervalMode, setStringFocus } = useActions(
+    actions => actions.intervals.settings
+  )
 
   return (
     <Settings>
       <Select
         size="sm"
-        placeholder="Small"
+        placeholder="Basic"
         defaultValue={intervalMode}
         onChange={mode => setIntervalMode(mode)}
       >
@@ -21,6 +26,23 @@ export const IntervalsSettings = () => {
           <option value="advanced" disabled>
             Advanced
           </option>
+        </optgroup>
+      </Select>
+
+      <Select
+        size="sm"
+        placeholder="All strings"
+        defaultValue={stringFocus}
+        onChange={index => setStringFocus(Number(index) as StringRange)}
+      >
+        <optgroup label="String Focus">
+          <option value={-1}>All strings</option>
+          <option value={0}>String 1</option>
+          <option value={1}>String 2</option>
+          <option value={2}>String 3</option>
+          <option value={3}>String 4</option>
+          <option value={4}>String 5</option>
+          <option value={5}>String 6</option>
         </optgroup>
       </Select>
     </Settings>

--- a/src/apps/intervals/state/intervalSettingsState.ts
+++ b/src/apps/intervals/state/intervalSettingsState.ts
@@ -1,8 +1,9 @@
 import { Action } from "easy-peasy"
+import { StringFocus } from "src/apps/notes/state/noteSettingsState"
 
 /**
- * Basic focuses on most common intervals; intermediate incorporates the g
- * string; advanced includes both basic and intermediate.
+ * Basic focuses on most common intervals; intermediate incorporates downward
+ * intervals; advanced includes both basic and intermediate, with offsets.
  *
  * TODO:
  * Include mode that takes a random position -- say, a 4th -- and then
@@ -15,16 +16,25 @@ export interface IntervalsSettings {
   intervalMode: IntervalMode
   showIntervals: boolean
 
+  // FIXME: Consolidate this with the notes app
+  stringFocus: StringFocus
+
   setIntervalMode: Action<IntervalsSettings, IntervalMode>
+  setStringFocus: Action<IntervalsSettings, StringFocus>
   toggleShowIntervals: Action<IntervalsSettings, void>
 }
 
 export const intervalsSettingsState: IntervalsSettings = {
   intervalMode: "basic",
   showIntervals: false,
+  stringFocus: -1, // -1 is disabled
 
   setIntervalMode: (state, intervalMode) => {
     state.intervalMode = intervalMode
+  },
+
+  setStringFocus: (state, stringFocus) => {
+    state.stringFocus = stringFocus
   },
 
   toggleShowIntervals: state => {

--- a/src/apps/intervals/state/intervalState.ts
+++ b/src/apps/intervals/state/intervalState.ts
@@ -38,6 +38,7 @@ export interface Intervals {
   listeners: Listen<Intervals>
 
   // Actions
+  exitRootCycle: Action<Intervals, void>
   maybeEnterRootCycle: Action<Intervals, void>
   pickAnswer: Thunk<Intervals, any, any, StoreModel>
   pickRandomInterval: Thunk<Intervals, void, any, StoreModel>
@@ -65,6 +66,7 @@ export const intervalState: Intervals = {
   listeners: listen(on => {
     const newIntervalsActions = [
       intervalsSettingsState.setIntervalMode,
+      intervalsSettingsState.setStringFocus,
       settingsState.setFretboardMode,
     ]
 
@@ -74,6 +76,7 @@ export const intervalState: Intervals = {
       on(
         action,
         thunk(actions => {
+          actions.exitRootCycle()
           actions.pickRandomInterval()
         })
       )
@@ -123,7 +126,7 @@ export const intervalState: Intervals = {
         currentInterval,
         currentRoot,
         rootCycle,
-        settings: { intervalMode },
+        settings: { intervalMode, stringFocus },
       },
     } = getState()
 
@@ -137,6 +140,7 @@ export const intervalState: Intervals = {
         fretboard,
         intervalMode,
         rootNote,
+        stringFocus,
       })
 
       // Current and new are the same
@@ -218,5 +222,9 @@ export const intervalState: Intervals = {
         state.rootCycle.currentIndex = 0
       }
     }
+  },
+
+  exitRootCycle: state => {
+    state.rootCycle.enabled = false
   },
 }

--- a/src/utils/intervals/getInterval.ts
+++ b/src/utils/intervals/getInterval.ts
@@ -4,14 +4,21 @@ import { IntervalMode } from "src/apps/intervals/state/intervalSettingsState"
 import { getIntervalByNote } from "src/utils/intervals/getIntervalByNote"
 import { Fretboard, Interval, Note } from "src/utils/types"
 import { computeRelativeInterval } from "./computeRelativeInterval"
+import { StringFocus } from "src/apps/notes/state/noteSettingsState"
 
 export function getInterval(props: {
   fretboard: Fretboard
   intervalMode?: IntervalMode
   rootNote?: Note
+  stringFocus?: StringFocus
 }): Interval {
-  const { intervalMode = "basic", rootNote: _rootNote } = props
-  const rootNote = _rootNote || getNote()
+  const {
+    intervalMode = "basic",
+    rootNote: _rootNote,
+    stringFocus = -1,
+  } = props
+
+  const rootNote = _rootNote || getNote({ stringFocus })
   const intervalNote = getNote()
 
   // Rerun function if we've landed on same note


### PR DESCRIPTION
Closes https://github.com/damassi/fretboard-trainer/issues/50

Since intervals change due to the inconsistent 3rd string tuning, it's helpful to be able to focus only on strings _around_ the third to learn the special intervals involved. 

![stringfocus](https://user-images.githubusercontent.com/236943/57504877-17749080-72ab-11e9-8a6c-18e083971869.gif)
